### PR TITLE
Adds manual language switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ This app supports dynamic localization using [i18next](https://www.i18next.com/)
 
 ### Adding new text to localizations
 
-As features are added to the calculator, they'll most likely not be localised immediately. To localise any new text in the app, make sure to first wrap the text in the `i18n.t()` method. Then, in your language's `translation.json`, add a new JSON key/value pair with the key used in the `t()` method, using your translated text as the value.
+As features are added to the calculator, they'll most likely not be localised immediately. To localise any new text in the app, make sure to first wrap the text in the `t()` method taken from the `useTranslation()` hook. Then, in your language's `translation.json`, add a new JSON key/value pair with the key used in the `t()` method, using your translated text as the value.
 
-For example, let's say we're adding a new button that says "Show Current Pattern". In the component where that text would be displayed, you would instead write `i18n.t("Show Current Pattern")`, wrapping the statement in brackets `{}` if it were part of JSX code.
+For example, let's say we're adding a new button that says "Show Current Pattern". In the component where that text would be displayed, you would instead write `t("Show Current Pattern")`, wrapping the statement in brackets `{}` if it were part of JSX code.
 
 Then, to add a translation to your language, you'd go to your languages `translation.json` file, and add the following line (using Spanish as an example):
 
 `"Show Current Pattern": "Mostrar Patrón Actual",`
 
-If no key is specified in the localization files, the app will simply display whatever text is passed into `i18n.t()`, to avoid errors.
+If no key is specified in the localization files, the app will simply display whatever text is passed into `t()`, to avoid errors.
 
 ### Creating new localizations
 
@@ -38,5 +38,7 @@ To localise the app to a new language, the following simple steps need to be don
 - Edit the `translation.json` file to translate each untranslated JSON value to the appropriate translated equivalent in your language.
 - In `/src/i18n.js`, create an `import` statement for your language, importing the `translation.json` file you just created. Follow the pattern used by the existing statements.
 - In the same file (`/src/i18n.js`), add your language to the list of languages inside the `resources` object within the `i18n.init()` method, following the pattern of other declared languages, and using the same two-letter language tag you used for the folder name in the first step.
+- Lastly, to add your language to the manual language switcher on the page, make sure to edit the `Localizer` component at `/src/Localizer.jsx`. Add a tuple for your language to the `languages` array, with the first value being your two-letter language code and the second value being the name of your language, in your language. 
+  - For example, to add Japanese to the list, you'd add `["ja", "日本人"],`
 
 The localization is now ready to deploy and will appear to users who use your language for their browser.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,9 +6,15 @@ import Filter from "./Filter";
 import Chart from "./Chart";
 import Title from "./Title";
 import Footer from "./Footer";
+import { useTranslation } from "react-i18next";
 
 const App = () => {
   const [filters, onChange] = useLocalStorage("filters", []);
+
+  const { t } = useTranslation();
+
+  // allows title to be localised
+  document.title = t("Turnip Calculator");
 
   const sanitizedInputFilters = useMemo(
     () =>

--- a/src/Chart.jsx
+++ b/src/Chart.jsx
@@ -11,9 +11,9 @@ import {
 } from "./v2/optimizer";
 import { Box } from "@material-ui/core";
 import { useDebounce } from "react-use";
-import i18n from "./i18n";
+import { useTranslation } from "react-i18next";
 
-const generateData = (filter) => {
+const generateData = (filter, t) => {
   let patterns = possiblePatterns(filter);
   const patternCount = patterns.reduce((acc, cur) => acc + cur.length, 0);
   if (patternCount === 0) patterns = possiblePatterns([0, ...filter.slice(1)]);
@@ -25,7 +25,7 @@ const generateData = (filter) => {
 
   return [
     {
-      label: i18n.t("Buy Price"),
+      label: t("Buy Price"),
       data: new Array(12).fill(filter[0] || null),
       fill: true,
       backgroundColor: "transparent",
@@ -35,7 +35,7 @@ const generateData = (filter) => {
       borderDash: [5, 15],
     },
     {
-      label: i18n.t("Guaranteed Min"),
+      label: t("Guaranteed Min"),
       data: new Array(12).fill(minWeekValue || null),
       fill: true,
       backgroundColor: "transparent",
@@ -45,14 +45,14 @@ const generateData = (filter) => {
       borderDash: [3, 6],
     },
     {
-      label: i18n.t("Daily Price"),
+      label: t("Daily Price"),
       data: Array.from({ length: 12 }, (v, i) => filter[i + 1] || null),
       fill: false,
       backgroundColor: "#EF8341",
       borderColor: "#EF8341",
     },
     {
-      label: i18n.t("Average"),
+      label: t("Average"),
       data: avgData[0] ? avgData[0].map(Math.trunc) : new Array(12).fill(null),
       backgroundColor: "#F0E16F",
       borderColor: "#F0E16F",
@@ -60,7 +60,7 @@ const generateData = (filter) => {
       fill: false,
     },
     {
-      label: i18n.t("Maximum"),
+      label: t("Maximum"),
       data: minMaxData[1] || new Array(12).fill(null),
       backgroundColor: "#A5D5A5",
       borderColor: "#A5D5A5",
@@ -69,7 +69,7 @@ const generateData = (filter) => {
       fill: 3,
     },
     {
-      label: i18n.t("Minimum"),
+      label: t("Minimum"),
       data: minMaxData[0] || new Array(12).fill(null),
       backgroundColor: "#88C9A1",
       borderColor: "#88C9A1",
@@ -83,6 +83,7 @@ const generateData = (filter) => {
 const ChartComponent = ({ filter }) => {
   const canvas = useRef();
   const chart = useRef();
+  const { t, i18n } = useTranslation();
 
   useLayoutEffect(() => {
     const ctx = canvas.current.getContext("2d");
@@ -90,18 +91,8 @@ const ChartComponent = ({ filter }) => {
     chart.current = new Chart(ctx, {
       type: "line",
       data: {
-        datasets: generateData(filter),
-        labels: i18n
-          .t("Mon Tue Wed Thu Fri Sat")
-          .split(" ")
-          .reduce(
-            (acc, day) => [
-              ...acc,
-              `${day} ${i18n.t("AM")}`,
-              `${day} ${i18n.t("PM")}`,
-            ],
-            []
-          ),
+        datasets: generateData(filter, t),
+        labels: getLabels(),
       },
       options: {
         maintainAspectRatio: false,
@@ -132,16 +123,34 @@ const ChartComponent = ({ filter }) => {
     });
   }, []);
 
-  useDebounce(
-    () => {
-      if (!chart.current) return;
-      const newData = generateData(filter);
-      merge(chart.current.data.datasets, newData);
-      chart.current.update();
-    },
-    500,
-    [filter]
-  );
+  useDebounce(updateChart, 500, [filter]);
+
+  // required to update the chart each time language is changed
+  i18n.on('languageChanged', updateChart);
+
+  function updateChart() {
+    if (!chart.current) return;
+    // regerates chart in the new 
+    const newData = generateData(filter, t);
+    merge(chart.current.data.datasets, newData);
+    // this is necessary, or else labels won't change language until reload
+    const newLabels = getLabels();
+    merge(chart.current.data.labels, newLabels);
+    chart.current.update();
+  }
+
+  function getLabels() {
+    return t("Mon Tue Wed Thu Fri Sat")
+    .split(" ")
+    .reduce(
+      (acc, day) => [
+        ...acc,
+        `${day} ${t("AM")}`,
+        `${day} ${t("PM")}`,
+      ],
+      []
+    );
+  }
 
   return (
     <Box p={2} mt={2} borderRadius={16} bgcolor="bkgs.chart">

--- a/src/Filter.jsx
+++ b/src/Filter.jsx
@@ -8,7 +8,7 @@ import {
   Box,
   makeStyles,
 } from "@material-ui/core";
-import i18n from "./i18n";
+import { useTranslation } from "react-i18next";
 import bells from './images/bells.png';
 
 const useButtonStyles = makeStyles((theme) => ({
@@ -24,6 +24,7 @@ const useButtonStyles = makeStyles((theme) => ({
 }));
 
 const ClearButton = (props) => {
+  const { t } = useTranslation();
   const classes = useButtonStyles();
   return (
     <Button
@@ -33,19 +34,13 @@ const ClearButton = (props) => {
       variant="contained"
       {...props}
     >
-      {i18n.t("Clear All Data!")}
+      {t("Clear All Data!")}
     </Button>
   );
 };
 
-const names = [
-  i18n.t("Buy Price"),
-  ...i18n.t("Mon Tue Wed Thu Fri Sat")
-    .split(" ")
-    .reduce((curr, day) => [...curr, ...[`${day} ${i18n.t('AM')}`, `${day} ${i18n.t('PM')}`]], []),
-];
-
 const Filter = ({ filters, onChange }) => {
+  const { t } = useTranslation();
   const handleChange = useCallback(
     (index) => ({
       target: {
@@ -61,6 +56,13 @@ const Filter = ({ filters, onChange }) => {
     },
     [filters, onChange]
   );
+
+  const names = [
+    t("Buy Price"),
+    ...t("Mon Tue Wed Thu Fri Sat")
+      .split(" ")
+      .reduce((curr, day) => [...curr, ...[`${day} ${t('AM')}`, `${day} ${t('PM')}`]], []),
+  ];
 
   const fields = Array.from({ length: 13 }, (v, i) => i).map((index) => (
     <TextField

--- a/src/Footer.jsx
+++ b/src/Footer.jsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { Box, Typography, Link as MaterialLink } from "@material-ui/core";
 import { Trans } from "react-i18next";
+import Localizer from "./Localizer";
 import { string, node } from "prop-types";
-import i18n from "./i18n";
+import { useTranslation } from "react-i18next";
 
 const Link = ({ href, gh, children }) => (
   <MaterialLink
@@ -16,7 +17,7 @@ const Link = ({ href, gh, children }) => (
 Link.propTypes = {
   href: string,
   gh: string,
-  children: node.required,
+  children: node,
 };
 Link.defaults = {
   href: undefined,
@@ -24,6 +25,7 @@ Link.defaults = {
 };
 
 const Footer = () => {
+  const { t } = useTranslation();
   return (
     <Box
       my={4}
@@ -34,7 +36,7 @@ const Footer = () => {
       borderRadius={16}
     >
       <Box my={2}>
-        <Typography variant="h5">{i18n.t("Usage")}</Typography>
+        <Typography variant="h5">{t("Usage")}</Typography>
         <Typography variant="body1">
           <Trans i18nKey="buyPriceInfo">
             - The <b>Buy Price</b> value is for your own island. It doesn&#39;t
@@ -53,7 +55,7 @@ const Footer = () => {
         </Typography>
       </Box>
       <Box my={2}>
-        <Typography variant="h5">{i18n.t("About")}</Typography>
+        <Typography variant="h5">{t("About")}</Typography>
         <Typography variant="body1">
           <Trans i18nKey="contributors">
             Thank you all contributors so far!
@@ -103,6 +105,9 @@ const Footer = () => {
         <Typography variant="body1" align="right">
           v1.5
         </Typography>
+      </Box>
+      <Box>
+        <Localizer />
       </Box>
     </Box>
   );

--- a/src/Localizer.jsx
+++ b/src/Localizer.jsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Box, Breadcrumbs, Link } from "@material-ui/core";
+import { useTranslation } from "react-i18next";
+
+const Localizer = () => {
+  const { i18n } = useTranslation();
+
+  const changeLanguage = lng => {
+    i18n.changeLanguage(lng);
+  };
+
+  const languages = [
+    ["en", "English"],
+    ["de", "Deutsche"],
+    ["es", "Español"],
+    ["fr", "Français"],
+    ["it", "Italiano"],
+    ["zh-CN", "简体中文"],
+    ["zh-TW", "繁体中文（台湾）"],
+    ["zh-HK", "繁体中文（香港）"],
+    ["ko", "한국어"],
+  ];
+
+  const languageList = [];
+
+  languages.map(([tag, name]) => {
+    languageList.push(<Link key={tag} href="#" onClick={() => {changeLanguage(tag)}}>{name}</Link>)
+  });
+
+  return (
+    <Box
+      borderRadius={16}
+      display="flex"
+      flexDirection="column"
+    >
+      <Breadcrumbs maxItems={languageList.length} aria-label="breadcrumb">
+        {languageList}
+      </Breadcrumbs>
+    </Box>
+  );
+};
+
+export default Localizer;

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -70,6 +70,10 @@ i18n
       },
     },
 
+    react: {
+      useSuspense: false
+    },
+
     // have a common namespace used around the full app
     ns: ["translations"],
     defaultNS: "translations",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,9 +1,5 @@
 import React from "react";
 import { render } from "react-dom";
 import App from "./App";
-import i18n from "./i18n";
-
-// allows title to be localised
-document.title = i18n.t("Turnip Calculator");
 
 render(<App />, document.getElementById("root"));


### PR DESCRIPTION
This PR adds a manual language switcher at the bottom of the page for those who want the page displayed in a language different from their normal browser language. Selected language is cached in local storage and stays persistent between different visits.

Live demo can be found [at my fork](https://mtaylor76.github.io/Turnip-Calculator/), feel free to fiddle around with it and see what needs improving.

Closes #29.

## Demo

![image](https://user-images.githubusercontent.com/31743217/78841620-da89b000-79cb-11ea-90fb-cd7894cceff3.png)
