### PR TITLE
update README with local dev section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ You can find the live calculator [here](https://elxris.github.io/Turnip-Calculat
 
 Looking for an API? [See this](https://github.com/elxris/Turnip-Calculator/issues/72#issuecomment-617483396)
 
+## Local Development
+
+To run this application locally, run the following commands:
+
+```
+git clone git@github.com:elxris/Turnip-Calculator.git
+cd Turnip-Calculator
+npm i
+npm start
+```
+
 ## Localizations
 
 ### For translators

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "react-app-rewired build",
     "postinstall": "node scripts/i18n.js",
     "prebuild": "yarn version --no-git-tag-version --no-commit-hooks --prerelease --preid build",
-    "start": "BROWSER=none react-app-rewired start"
+    "start": "react-app-rewired start"
   },
   "devDependencies": {
     "@babel/core": "7.9.6",


### PR DESCRIPTION
- Closes https://github.com/elxris/Turnip-Calculator/issues/126

## Description
Adds a `Local Development` section to the `README.md`.

## Issues so far not addressed in this PR
I encountered this error after running `npm start`:

```
'BROWSER' is not recognized as an internal or external command,
operable program or batch file.
```