### PR TITLE
Add a way for user to quickly tell which field corresponds to current time

### DIFF
--- a/src/containers/Filter.jsx
+++ b/src/containers/Filter.jsx
@@ -22,6 +22,10 @@ const useTextFieldStyles = makeStyles(() => ({
   },
 }));
 
+const now = new Date();
+const day = now.getDay();
+const hour = now.getHours();
+
 const Filter = ({ filters, onChange, openShareDialog }) => {
   const [clearDataDialogOpen, setClearDataDialogOpen] = useState(false);
   const { t } = useTranslation();
@@ -77,6 +81,8 @@ const Filter = ({ filters, onChange, openShareDialog }) => {
         },
       }}
       value={filters[index] || ""}
+      placeholder={(index + 1 === day * 2 + (hour >= 12 ? 1 : 0)) ||
+                   (day === 0 && index === 0) ? "Now" : ""}
       onChange={handleChange(index)}
     />
   ));


### PR DESCRIPTION
This PR makes it so a **"Now"** placeholder text appears for a field that corresponds to the current moment in time.

For example, on `Friday 2020, June 26, at 08:20 PM` user would see this:
![Friday PM as Now Example](https://i.imgur.com/ft1nGUp.png)
*Notice the **"Now"** placeholder text indicating that now is indeed Friday, PM.*

Please feel free to rewrite this in a better way as I am completely not versed in React, or to close the PR if the functionality doesn't seem necessary.